### PR TITLE
Use nearest filter for small icons

### DIFF
--- a/addons/InstanceDock/InstanceSlot.gd
+++ b/addons/InstanceDock/InstanceSlot.gd
@@ -76,8 +76,10 @@ func _get_drag_data(position: Vector2):
 	return {files = [scene], type = "files", from_slot = get_index()}
 
 func set_icon(texture: Texture2D):
-	icon.stretch_mode = TextureRect.STRETCH_SCALE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	icon.texture = texture
+	if texture and texture.get_width() <= icon.size.x:
+		icon.texture_filter = TEXTURE_FILTER_NEAREST
 	
 	if loading_icon.visible:
 		icon.modulate.a = 0


### PR DESCRIPTION
Enough said. Smaller icons look much better without blurring
![image](https://github.com/KoBeWi/Godot-Instance-Dock/assets/66727710/58d3eea0-532e-407b-839b-4d5e3a655f71)

This PR also tries to keep the icons' aspect ratio so that icons don't look comedically stretched
![image](https://github.com/KoBeWi/Godot-Instance-Dock/assets/66727710/fe470ba1-eb41-4a6e-a3c9-61c36abb14cd)

